### PR TITLE
disable for mk1 devices

### DIFF
--- a/ovos_PHAL_plugin_dotstar/__init__.py
+++ b/ovos_PHAL_plugin_dotstar/__init__.py
@@ -50,6 +50,24 @@ class DotStarLedControlPluginValidator(PHALValidator):
     @staticmethod
     def validate(config=None):
         # If the user enabled the plugin no need to go further
+        """
+        Validate the configuration for the DotStar LED control plugin.
+        
+        Determines whether the plugin should be activated based on configuration and hardware detection.
+        
+        Parameters:
+            config (dict, optional): Plugin configuration dictionary. Defaults to None.
+        
+        Returns:
+            bool: True if the plugin should be enabled, False otherwise.
+        
+        Conditions for validation:
+            1. If plugin is explicitly enabled in configuration
+            2. If specific audio hardware is detected (WM8960, ReSpeaker 4-mic, ReSpeaker 6-mic)
+            3. Excludes Mark 1 hardware configuration
+        
+        Logs debug information about validation process.
+        """
         if config.get("enabled"):
             LOG.debug("user enabled")
             return True

--- a/ovos_PHAL_plugin_dotstar/__init__.py
+++ b/ovos_PHAL_plugin_dotstar/__init__.py
@@ -14,7 +14,7 @@ from ovos_plugin_manager.templates.phal import PHALValidator
 from ovos_utils.log import LOG
 from ovos_config.config import Configuration
 
-from ovos_i2c_detection import is_wm8960, is_respeaker_4mic, is_respeaker_6mic
+from ovos_i2c_detection import is_wm8960, is_respeaker_4mic, is_respeaker_6mic, is_mark_1
 
 from lingua_franca.util.colors import Color
 from lingua_franca.internal import load_language
@@ -55,6 +55,9 @@ class DotStarLedControlPluginValidator(PHALValidator):
             return True
         # Try a direct hardware check
         if is_wm8960() or is_respeaker_4mic() or is_respeaker_6mic():
+            if is_mark_1():
+                LOG.debug("Mark 1 detected.  Dotstar is not needed")
+                return False
             LOG.debug("direct hardware check")
             return True
         LOG.debug("no validation")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 adafruit-circuitpython-dotstar
 ovos-plugin-manager>=0.0.1
 ovos-lingua-franca>=0.4.8a8
-ovos-i2c-detection>=0.0.0a5
+ovos-i2c-detection>=0.0.5
 gpiozero
 rpi-lgpio


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added hardware detection logic to prevent DotStar LED plugin activation on Mark 1 hardware.

- **Dependencies**
	- Updated `ovos-i2c-detection` package to version 0.0.5 or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->